### PR TITLE
Add AnimatedAgent and Animated

### DIFF
--- a/src/modules/animated-agent/animate-callback-options.js
+++ b/src/modules/animated-agent/animate-callback-options.js
@@ -1,0 +1,47 @@
+export default class AnimateCallbackOptions {
+  constructor() {
+    this._agent = null;
+    this.animated = null;
+    this.animatedEl = null;
+    this.lastRect = null;
+    this.rect = null;
+  }
+
+  set(agent, animated, animatedEl, lastRect, rect) {
+    this._agent = agent;
+    this.animated = animated;
+    this.animatedEl = animatedEl;
+    this.lastRect = lastRect;
+    this.rect = rect;
+    return this;
+  }
+
+  transitionFromLast(duration) {
+    return this.transitionFrom(this.lastRect, this.rect, duration);
+  }
+
+  animateFromLast(duration) {
+    return this.animateFrom(this.lastRect, this.rect, duration);
+  }
+
+  transitionFrom(lastRect, rect, duration) {
+    return this._agent.transitionFrom(this.animated, this.animatedEl, lastRect, rect, duration);
+  }
+
+  animateFrom(lastRect, rect, duration) {
+    return this._agent.animateFrom(this.animated, this.animatedEl, lastRect, rect, duration);
+  }
+
+  removeStyle() {
+    this._agent.removeAnimatedStyle(this.animated, this.animatedEl);
+  }
+
+  setStyle(style) {
+    this._agent.setAnimatedStyle(this.animated, this.animatedEl, style);
+  }
+
+  timer(fn) {
+    const timer = this._agent.timer(fn);
+    return timer;
+  }
+}

--- a/src/modules/animated-agent/animate-timer.js
+++ b/src/modules/animated-agent/animate-timer.js
@@ -1,0 +1,73 @@
+export default class AnimateTimer {
+  constructor() {
+    this.run = 1;
+    this._oncancel = null;
+    this.promise = Promise.resolve();
+  }
+
+  _init(fn = function() {}) {
+    this._oncancel = null;
+    this.promise = Promise.resolve(fn.call(this, this));
+    return this;
+  }
+
+  frame() {
+    const run = this.run;
+    return new Promise(requestAnimationFrame)
+    .then(() => {
+      if (this.run !== run) {
+        throw new Error('Timer canceled');
+      }
+    });
+  }
+
+  timeout(delay) {
+    const run = this.run;
+    return new Promise(resolve => setTimeout(resolve, delay))
+    .then(() => {
+      if (this.run !== run) {
+        throw new Error('Timer canceled');
+      }
+    });
+  }
+
+  loop(fn) {
+    const run = this.run;
+    return new Promise((resolve, reject) => {
+      const loop = () => {
+        if (this.run !== run) {
+          reject(new Error('Timer canceled'));
+        }
+        else if (fn() >= 1) {
+          resolve();
+        }
+        else {
+          requestAnimationFrame(loop);
+        }
+      };
+      loop();
+    })
+    .then(() => {
+      if (this.run !== run) {
+        throw new Error('Timer canceled');
+      }
+    });
+  }
+
+  cancelable(fn) {
+    this._oncancel = fn;
+  }
+
+  cancel() {
+    this.run++;
+    let cancelResult;
+    if (this._oncancel) {
+      cancelResult = this._oncancel();
+    }
+    return cancelResult;
+  }
+
+  then(cb, eb) {
+    return this.promise.then(cb, eb);
+  }
+}

--- a/src/modules/animated-agent/index.jsx
+++ b/src/modules/animated-agent/index.jsx
@@ -1,0 +1,402 @@
+import 'core-js/modules/es6.object.assign';
+
+import React, {Children} from 'react';
+import {findDOMNode} from 'react-dom';
+
+import Component from '../update-ancestor';
+
+import AnimateCallbackOptions from './animate-callback-options';
+import AnimateTimer from './animate-timer';
+import Rect from './rect';
+
+/**
+ * AnimatedAgent
+ *
+ * Work with Animated wrapped React components to animate around the screen.
+ *
+ * AnimatedAgent and Animated can be used very simply to have a React component
+ * animate from one area of the window to another area. By default an Animated
+ * triggers an animation with the agent any time it goes through its render
+ * lifecycle. For easy use the default animation will animate linearly from its
+ * last location to the current location.
+ *
+ * Animateds can animate a React component from a previous hierarchy to a new
+ * hierarchy. Say you have two lists and want to animate one of the list items
+ * from one list to the other. As long as the old React element and the new one
+ * in the new list has an Animated wrapping element with the same animateKey,
+ * the agent will use the last remembered position and start an animation with
+ * that last position and the new one.
+ */
+export default class AnimationAgent extends Component {
+  constructor(...args) {
+    super(...args);
+    // The agent's rectangle in world space. Use to make transform world space
+    // rectangles into agent space rectangles.
+    this.rect = new Rect();
+    // Dictionary of Animated property animateKey to Animated react components.
+    this.animateds = {};
+    // Dictionary of Animated property animateKey to Rect representing the
+    // rectangular shape of the Animated's component in world space.
+    this.rects = {};
+    // Dictionary of Animated property animatedKey to an active animation.
+    // Animations are a duck type object returned by the Animated's animate
+    // property. Animations can have a `then` and `cancel` members. The then
+    // member is called to help reuse internal AnimationAgent objects to reduce
+    // time spent collecting garbage and object creation. The cancel member is
+    // used to stop an existing animation to remove race conditions from
+    // multiple animations running on the same Animated.
+    this.animations = {};
+    // Dictionary of Animated property animatedKey to style applied by
+    // AnimationAgent. Used internally to reapply the style when its removed
+    // when updating `this.rects` in cases like the window resizing.
+    this.styles = {};
+    // Dictionary of Animated property animatedKey to style replaced on an
+    // element. Used internally to remove applied style when updating
+    // `this.rects`.
+    this.replacedStyles = {};
+    // Pool of AnimateTimer objects that can be reused. This helps reduce
+    // object creation and garbage collection.
+    this.timerPool = [];
+    // Pool of AnimateCallbackOptions objects that can be reused. This helps
+    // reduce object creation and garbage collection.
+    this.optionsPool = [];
+    // Is this rendered in a browser or on the server as a string.
+    this.clientRender = typeof window !== 'undefined';
+    // Hold a promise that resolves soon. Used by soon() to group a set of calls
+    // as soon as possible, not immediately but also not on the next javascript
+    // tick caused by something like setTimeout. As its a promise it uses the
+    // Promise spec's detail that a resolved promise calls its callbacks at the
+    // end of the current javascript tick before the javascript engine hands off
+    // to the browser to do rendering.
+    this._soon = null;
+  }
+
+  getChildContext() {
+    return {animationAgent: this};
+  }
+
+  componentDidMount() {
+    if (this.clientRender) {
+      window.addEventListener('resize', this.resize);
+
+      // Determine the agent's starting rectangle.
+      Rect.getBoundingClientRect(findDOMNode(this), this.rect);
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.clientRender) {
+      // Determine the agent's updated rectangle.
+      Rect.getBoundingClientRect(findDOMNode(this), this.rect);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.clientRender) {
+      window.removeEventListener('resize', this.resize);
+    }
+  }
+
+  removeAnimatedStyle(animated, animatedEl) {
+    // Return an animated element to the style an animation replaced. This
+    // should return the element to how it was before the animation was played.
+    // This is used at times to return the element to the non animated state to
+    // query the DOM's layout. After use, the style is returned to that of the
+    // any current animation so a user never sees the change.
+    const animatedKey = animated.getAnimateKey();
+    if (!this.replacedStyles[animatedKey]) {
+      return;
+    }
+    Object.assign(animatedEl.style, this.replacedStyles[animatedKey]);
+    this.replacedStyles[animatedKey] = null;
+  }
+
+  setAnimatedStyle(animated, animatedEl, style) {
+    // Set the style of an animated element and store the style that was
+    // replaced. When style has new keys, record the replaced style. When style
+    // no longer has keys that have replaced values recorded, return those
+    // replaced values.
+    const animatedKey = animated.getAnimateKey();
+    if (!this.replacedStyles[animatedKey]) {
+      this.replacedStyles[animatedKey] = {};
+    }
+    const replaced = this.replacedStyles[animatedKey];
+    this.styles[animatedKey] = style;
+    for (const key in replaced) {
+      if (!style || !style.hasOwnProperty(key)) {
+        animatedEl.style[key] = replaced[key];
+        delete replaced[key];
+      }
+    }
+    // The end of an animation sets the style to a null object, removing any
+    // styling the animation had previously applied.
+    if (!style) {
+      this.replacedStyles[animatedKey] = null;
+      return;
+    }
+    for (const key in style) {
+      if (!replaced.hasOwnProperty(key)) {
+        replaced[key] = animatedEl.style[key];
+      }
+    }
+    Object.assign(animatedEl.style, style);
+  }
+
+  timer(fn) {
+    // Create a timer that can create easily cancelable animations by throwing
+    // an Error at any timed section when the animation is canceled.
+    const timer = this.timerPool.shift() || new AnimateTimer();
+    timer._init(fn);
+    // When the timer completes normally or abnormally (such as being canceled)
+    // add it to the timer pool so that it can be reusued.
+    timer.then(() => {
+      this.timerPool.unshift(timer);
+    }, () => {
+      this.timerPool.unshift(timer);
+    });
+    return timer;
+  }
+
+  animateFrom(animated, animatedEl, lastRect, rect, duration) {
+    if (lastRect.equal(rect)) {
+      return Promise.resolve();
+    }
+    // Animate from one rect to another. The target is treated as the elements
+    // origin so this animates from a relative position to (0, 0).
+    return this.timer(timer => {
+      return Promise.resolve()
+      .then(() => timer.frame())
+      .then(() => {
+        const start = Date.now();
+        const style = {
+          transform: null,
+          zIndex: 1,
+        };
+        // A temporary storage value that can be reused to reduce memory churn
+        // and very easily track the position in the animation in case its
+        // canceled.
+        const tRect = lastRect.clone();
+        // In case its canceled return the current location.
+        timer.cancelable(() => tRect);
+        // Loop animation frames until its done.
+        return timer.loop(() => {
+          const now = Date.now();
+          // A value from 0 to 1 representing the position in the animation.
+          const t = Math.min((now - start) / 1000 / duration, 1);
+          // Create a transform that is the difference from the position in the
+          // animation to the origin of the element.
+          style.transform = rect.interpolate(lastRect, t, tRect)
+          .transform(rect);
+          this.setAnimatedStyle(animated, animatedEl, style);
+          // Return a position in time, timer.loop will resolve the promise it
+          // create when t is greater than or equal to 1.
+          return t;
+        });
+      })
+      // Return any style set by the animation to their original values.
+      .then(() => this.setAnimatedStyle(animated, animatedEl));
+    });
+  }
+
+  transitionFrom(animated, animatedEl, lastRect, rect, duration) {
+    if (lastRect.equal(rect)) {
+      return Promise.resolve();
+    }
+    // Perform a css transition from one rect to another. The target is treated
+    // as the elements origin so this animates from a relative position to
+    // (0, 0).
+    return this.timer(timer => {
+      const start = Date.now();
+      const style = {
+        transform: lastRect.transform(rect),
+        transition: 'none',
+        zIndex: 1,
+      };
+      timer.cancelable(() => lastRect);
+      return Promise.resolve()
+      .then(() => timer.frame())
+      .then(() => {
+        // Set the initial point for the transition.
+        this.setAnimatedStyle(animated, animatedEl, style);
+        return timer.frame();
+      })
+      .then(() => {
+        // If canceled, try to represent where the animation currently has the
+        // element.
+        timer.cancelable(() => {
+          const t = (Date.now() - start) / 1000 / duration;
+          return rect.interpolate(lastRect, Math.min(t, 1));
+        });
+        // Set up the transition by setting the transition style.
+        style.transition = `transform ${duration}s`;
+        this.setAnimatedStyle(animated, animatedEl, style);
+        // Start the transition to (0, 0).
+        style.transform = 'translateZ(0)';
+        this.setAnimatedStyle(animated, animatedEl, style);
+        // Wait until the transition should have completed.
+        return timer.timeout(duration * 1000);
+      })
+      // Return any style set by the animation to their original values.
+      .then(() => this.setAnimatedStyle(animated, animatedEl));
+    });
+  }
+
+  mountAnimated(animated) {
+    // A component has been created with a given key.
+    const key = animated.getAnimateKey();
+    if (this.animateds[key] !== animated) {
+      this.animateds[key] = animated;
+    }
+  }
+
+  unmountAnimated(animated) {
+    // A component will be destroy with a given key.
+    const key = animated.getAnimateKey();
+    if (this.animateds[key] === animated) {
+      this.animateds[key] = null;
+      // Cancel any existing animation. If another component is created with
+      // the same key it'll need to restart the animation. The animation is left
+      // so any such new component will "cancel" it again giving it the rect to
+      // continue with.
+      if (this.animations[key] && this.animations[key].cancel) {
+        this.animations[key].cancel();
+      }
+    }
+  }
+
+  willUpdateAnimated(animated) {
+    // Remove any animated style to reduce interference with react updating the
+    // DOM. Animations that were running need to be managed by their Animated
+    // in such a case as there isn't necessarily a general way to resume the
+    // animation.
+    if (this.clientRender) {
+      this.removeAnimatedStyle(animated, findDOMNode(animated));
+    }
+  }
+
+  _animate(key, animated, animatedEl, lastRect, rect) {
+    const options = this.optionsPool.shift() || new AnimateCallbackOptions();
+    options.set(this, animated, animatedEl, lastRect, rect);
+    this.animations[key] = animated.animate(options);
+    // If the animation is a thenable, use it to add the used options object
+    // into a pool so it can be reused.
+    if (this.animations[key] && this.animations[key].then) {
+      this.animations[key].then(() => {
+        this.animations[key] = null;
+        this.optionsPool.unshift(options);
+      }, error => {
+        this.animations[key] = null;
+        this.optionsPool.unshift(options);
+
+        // Handle the Timer canceled error. Any other errors should be handled
+        // by the user and not AnimatedAgent.
+        if (error.message !== 'Timer canceled') {
+          throw error;
+        }
+      });
+    }
+  }
+
+  soon() {
+    if (!this._soon) {
+      this._soon = Promise.resolve()
+      .then(() => {
+        this._soon = null;
+      });
+    }
+    return this._soon;
+  }
+
+  updateAnimated(animated) {
+    // Cannot animate while server rendering.
+    if (!this.clientRender) {return;}
+
+    // Wait until the end of this JS frame so that all DOM changes can be
+    // applied before we access the DOM to know where the Animated object is.
+    this.soon()
+    .then(() => {
+      const key = animated.getAnimateKey();
+      const animatedEl = findDOMNode(animated);
+
+      if (this.rects[key]) {
+        // Determine where this Animated was before either through the last
+        // stored rect or by canceling a current animation and using its
+        // returned value.
+        let lastRect;
+        if (this.animations[key] && this.animations[key].cancel) {
+          lastRect = this.animations[key].cancel();
+        }
+        if (!lastRect) {
+          lastRect = this.rects[key].clone();
+        }
+        // Make sure the element has been laid out to whereever it needs to be.
+        (function() {})(animatedEl.offsetTop);
+        // Get where the Animated element currently is.
+        const rect = Rect.getBoundingClientRect(animatedEl, this.rects[key]);
+        // Use the Animated's animate property or a default to animate from
+        // where the object was to where it is now.
+        this._animate(key, animated, animatedEl, lastRect, rect);
+      }
+      else {
+        // No Animated has existed the moment before now with this key.
+        this.rects[key] = Rect.getBoundingClientRect(animatedEl);
+        const lastRect = this.rects[key].clone();
+        const rect = this.rects[key];
+        // Let the Animated "animate in" or in the best case do no animation.
+        this._animate(key, animated, animatedEl, lastRect, rect);
+      }
+    });
+  }
+
+  resize() {
+    // At the end of this JS frame query the DOM for the positions of all
+    // Animated objects. Since we normally only query when an element has been
+    // updated by React we can only know where the element is now, we need to
+    // use a stored value to know where it was. So when the window resizes or
+    // another event that would case children to reflow in the layout we need
+    // to request that info again. We do this instead of querying before an
+    // element is updated because that may trigger a layout or have been
+    // effected by siblings updating and the lifecycle step for a specific
+    // element happens in the middle of the whole set of React elements
+    // updating.
+    this.soon()
+    .then(() => {
+      // Temporarily remove animation styling so we can get the new rects.
+      for (const key in this.animateds) {
+        const animated = this.animateds[key];
+        if (animated) {
+          this.removeAnimatedStyle(animated, findDOMNode(animated));
+        }
+      }
+      // Get the new rects for all Animateds.
+      Rect.getBoundingClientRect(findDOMNode(this), this.rect);
+      for (const key in this.animateds) {
+        const animated = this.animateds[key];
+        if (animated) {
+          const animatedEl = findDOMNode(animated);
+          (function() {})(animatedEl.offsetTop);
+          Rect.getBoundingClientRect(animatedEl, this.rects[key]);
+        }
+      }
+      // Reapply any animation styles
+      for (const key in this.animateds) {
+        const animated = this.animateds[key];
+        if (animated) {
+          this.setAnimatedStyle(animated, findDOMNode(animated), this.styles[key]);
+        }
+      }
+    });
+  }
+
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+
+AnimationAgent.childContextTypes = {
+  animationAgent: React.PropTypes.any,
+};
+
+AnimationAgent.propTypes = {
+  children: React.PropTypes.any,
+};

--- a/src/modules/animated-agent/rect.js
+++ b/src/modules/animated-agent/rect.js
@@ -1,0 +1,89 @@
+export default class Rect {
+  constructor(left = 0, top = 0, width = 0, height = 0, angle = 0) {
+    this.left = left;
+    this.top = top;
+    this.width = width;
+    this.height = height;
+    this.angle = angle;
+  }
+
+  relativeTo(rect) {
+    this.left -= rect.left;
+    this.top -= rect.top;
+    this.angle -= rect.angle;
+    return this;
+  }
+
+  set(left, top, width, height, angle = 0) {
+    this.left = left;
+    this.top = top;
+    this.width = width;
+    this.height = height;
+    this.angle = angle;
+    return this;
+  }
+
+  clone(dst = new Rect()) {
+    return dst.copy(this);
+  }
+
+  copy(src) {
+    this.left = src.left;
+    this.top = src.top;
+    this.width = src.width;
+    this.height = src.height;
+    this.angle = src.angle || 0;
+    return this;
+  }
+
+  interpolate(last, t, dst = new Rect()) {
+    return dst.set(
+      (this.left - last.left) * t + last.left,
+      (this.top - last.top) * t + last.top,
+      (this.width - last.width) * t + last.width,
+      (this.height - last.height) * t + last.height,
+      (this.angle - last.angle) * t + last.angle
+    );
+  }
+
+  equal(other) {
+    return (
+      this.left === other.left &&
+      this.top === other.top &&
+      this.width === other.width &&
+      this.height === other.height &&
+      this.angle === other.angle
+    );
+  }
+
+  transform(last) {
+    let transform;
+    const leftDiff = this.left - last.left;
+    const topDiff = this.top - last.top;
+    if (last.width !== this.width || last.height !== this.height) {
+      const {width, height} = this;
+      const widthScale = width / last.width;
+      const heightScale = height / last.height;
+      if (last.angle !== this.angle) {
+        const angleDiff = this.angle - last.angle;
+        transform = `translate3d(${leftDiff}px, ${topDiff}px, 0)` +
+          ` scale(${widthScale}, ${heightScale}) rotateZ(${angleDiff}rad)`;
+      }
+      else {
+        transform = `translate3d(${leftDiff}px, ${topDiff}px, 0) scale(${widthScale}, ${heightScale})`;
+      }
+    }
+    else if (last.angle !== this.angle) {
+      const angleDiff = this.angle - last.angle;
+      transform = `translate3d(${leftDiff}px, ${topDiff}px, 0) rotateZ(${angleDiff}rad)`;
+    }
+    else {
+      transform = `translate3d(${leftDiff}px, ${topDiff}px, 0)`;
+    }
+    return transform;
+  }
+}
+
+Rect.getBoundingClientRect = function(element, dst = new Rect()) {
+  return dst.copy(element.getBoundingClientRect());
+};

--- a/src/modules/animated/index.js
+++ b/src/modules/animated/index.js
@@ -1,0 +1,112 @@
+import React, {Children} from 'react';
+
+import Component from '../auto-bind-ancestor';
+
+/**
+ * Animated
+ *
+ * Animated wraps React elements and provides a hook to overwrite a simple
+ * transition animation for whenever a React element is updated or rerendered.
+ *
+ * ```js
+ * <AnimatedAgent>
+ *   <ol>
+ *     {list.map(item => <Animated
+ *       key={item.key}
+ *       animateKey={item.key}>
+ *       <li>{item.name}</li>
+ *     </Animated>)}
+ *   </ol>
+ * </AnimatedAgent>
+ * ```
+ *
+ * Animated and Agent rely on animateKey to determine where an Animated element
+ * was last on the screen and animate from that position. As such animateKey is
+ * required and unlike key should be unique in all Animated elements under an
+ * Agent. In the given above example if an the list was sorted or an item added
+ * or removed. The items in the list would animate from their previous position
+ * to the new position. Animated doesn't directly support animating removed
+ * items, for that you'd need to combine Animated with ReactTransitionGroup to
+ * persist the removed item until its removal animation completes.
+ *
+ * Animated takes an animate property to define custom animations.
+ *
+ * ```js
+ * <Animated animateKey={uniqueKey} animate={options => {
+ *   const {rect, lastRect} = options;
+ *   if (this.justAddedItem(item)) {
+ *     lastRect.height = 0;
+ *   }
+ *   if (this.justRemovedItem(item)) {
+ *     rect.height = 0;
+ *   }
+ *   return options.animateFrom(lastRect, rect, 0.3);
+ * }}><li>{item.name}</li></Animated>
+ * ```
+ *
+ * Since the animateKey is unique on the page, an Animated can be removed from
+ * one part of the DOM's hierarchy and added to another. A simple example is
+ * moving an animated from one list to another.
+ *
+ * ```js
+ * <AnimatedAgent>
+ *   <ol>
+ *     {list1.map(item => <Animated
+ *       key={item.key}
+ *       animateKey={item.key}>
+ *       <li>{item.name}</li>
+ *     </Animated>)}
+ *   </ol>
+ *   <ol>
+ *     {list2.map(item => <Animated
+ *       key={item.key}
+ *       animateKey={item.key}>
+ *       <li>{item.name}</li>
+ *     </Animated>)}
+ *   </ol>
+ * </AnimatedAgent>
+ * ```
+ */
+export default class Animated extends Component {
+  componentDidMount() {
+    this.context.animationAgent.mountAnimated(this);
+    this.context.animationAgent.updateAnimated(this);
+  }
+
+  componentWillUpdate() {
+    this.context.animationAgent.willUpdateAnimated(this);
+  }
+
+  componentDidUpdate() {
+    this.context.animationAgent.updateAnimated(this);
+  }
+
+  componentWillUnmount() {
+    this.context.animationAgent.unmountAnimated(this);
+  }
+
+  getAnimateKey() {
+    return this.props.animateKey;
+  }
+
+  animate(options) {
+    if (this.props.animate) {
+      return this.props.animate(options);
+    }
+    return options.animateFromLast(0.3);
+  }
+
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+
+Animated.contextTypes = {
+  animationAgent: React.PropTypes.any,
+};
+
+Animated.propTypes = {
+  children: React.PropTypes.any,
+  animateKey: React.PropTypes.any.isRequired,
+  animate: React.PropTypes.any,
+};


### PR DESCRIPTION
Animated wraps React elements and provides a hook to overwrite a simple transition animation for whenever a React element is updated or rerendered.

```js
<AnimatedAgent>
  <ol>
    {list.map(item => <Animated key={item.key} animateKey={item.key}><li>{item.name}</li></Animated>)}
  </ol>
</AnimatedAgent>
```

Animated and Agent rely on animateKey to determine where an Animated element was last on the screen and animate from that position. As such animateKey is required and unlike key should be unique in all Animated elements under an Agent. In the given above example if an the list was sorted or an item added or removed. The items in the list would animate from their previous position to the new position. Animated doesn't directly support animating removed items, for that you'd need to combine Animated with ReactTransitionGroup to persist the removed item until its removal animation completes.

Animated takes an animate property to define custom animations.

```js
<Animated animateKey={uniqueKey} animate={options => {
  const {rect, lastRect} = options;
  if (this.justAddedItem(item)) {
    lastRect.height = 0;
  }
  if (this.justRemovedItem(item)) {
    rect.height = 0;
  }
  return options.animateFrom(lastRect, rect, 0.3);
}}><li>{item.name}</li></Animated>
```

Since the animateKey is unique on the page, an Animated can be removed from one part of the DOM's hierarchy and added to another. A simple example is moving an animated from one list to another.

```js
<AnimatedAgent>
  <ol>
    {list1.map(item => <Animated key={item.key} animateKey={item.key}><li>{item.name}</li></Animated>)}
  </ol>
  <ol>
    {list2.map(item => <Animated key={item.key} animateKey={item.key}><li>{item.name}</li></Animated>)}
  </ol>
</AnimatedAgent>
```